### PR TITLE
Fix usage of developer keys

### DIFF
--- a/apiary.js
+++ b/apiary.js
@@ -210,7 +210,7 @@
   };
 
   /**
-   * Find the largest photo available from an array of them.
+   * GET data from the API, using the API key.
    *
    * @param {String}   url      target URL, including base URL and parameters, but not an API key.
    * @param {Function} callback <code>function(json){}</code>
@@ -218,11 +218,15 @@
 
   var get = function(url, callback) {
 
-    $.ajax({
-      headers: {'Authorization': 'W3C-API apikey="' + apiKey + '"'},
-      url:     url,
-      success: callback
-    });
+    var newUrl = url;
+
+    if (-1 === newUrl.indexOf('?')) {
+      newUrl += '?apikey=' + apiKey;
+    } else if (-1 === newUrl.toLowerCase().indexOf('apikey=')) {
+      newUrl += '&apikey=' + apiKey;
+    }
+
+    $.get(newUrl, callback);
 
   };
 


### PR DESCRIPTION
Correction over #12:

_Add support for [API keys](https://w3c.github.io/w3c-api/#apikeys) with an ~~`Authorization` header~~ [`apikey` parameter](https://w3c.github.io/w3c-api/#use)._

My previous PR was incomplete because I wasn't handling CORS properly. This method is simpler and faster (saves one HTTP request).

Fix #4.
