### PR TITLE
Remove field “activities” (and add “groups”) to domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ These are all the supported placeholders now:
 
 Placeholder             | Applies to             | Generated content
 :-----------------------|:-----------------------|:-----------------
-`apiary-activities`     | domains                | `<ul>`
+`apiary-groups`         | domains                | `<ul>`
 `apiary-chairs`         | groups                 | `<ul>`
 `apiary-description`    | groups                 | text
 `apiary-family`         | users                  | text

--- a/apiary.js
+++ b/apiary.js
@@ -10,7 +10,7 @@
   var TYPE_DOMAIN_PAGE    = 1;
   var TYPE_GROUP_PAGE     = 2;
   var TYPE_USER_PAGE      = 3;
-  var TYPE_ACTIVITIES     = 4;
+  var TYPE_GROUPS         = 4;
   var TYPE_CHAIRS         = 5;
   var TYPE_SPECIFICATIONS = 6;
 
@@ -81,7 +81,7 @@
    *     <h1> element
    *   ],
    *   lead: [<div> element],
-   *   activities: [<div> element]
+   *   groups: [<div> element]
    * }
    */
 
@@ -115,8 +115,8 @@
         get(BASE_URL + 'domains/' + value, function(json) {
           data.name = json.name;
           data.lead = json._links.lead.title;
-          if (placeholders.activities) {
-            digDownData(TYPE_ACTIVITIES, json._links.activities.href, callback);
+          if (placeholders.groups) {
+            digDownData(TYPE_GROUPS, json._links.groups.href, callback);
           } else if (callback) {
             callback.call();
           }
@@ -159,21 +159,21 @@
   /**
    * Get data recursively, given a URL and the type of data.
    *
-   * @param {TYPE}     item     eg TYPE_ACTIVITIES
-   * @param {String}   url      eg “https://api-test.w3.org/domains/109/activities”
+   * @param {TYPE}     item     eg TYPE_GROUPS
+   * @param {String}   url      eg “https://api-test.w3.org/domains/109/groups”
    * @param {Function} callback eg injectValues
    */
 
   var digDownData = function(item, url, callback) {
     var list, i;
     get(url, function(json) {
-      if (TYPE_ACTIVITIES === item) {
+      if (TYPE_GROUPS === item) {
         list = '<ul>';
-        for (i = 0; i < json._links.activities.length; i ++) {
-          list += '<li>' + json._links.activities[i].title + '</li>';
+        for (i = 0; i < json._links.groups.length; i ++) {
+          list += '<li>' + json._links.groups[i].title + '</li>';
         }
         list += '</ul>';
-        data.activities = list;
+        data.groups = list;
       } else if (TYPE_CHAIRS === item) {
         list = '<ul>';
         for (i = 0; i < json._links.chairs.length; i ++) {

--- a/examples/domain.html
+++ b/examples/domain.html
@@ -18,8 +18,8 @@
       <h1 class="apiary apiary-name">[Loading…]</h1>
       <h2>Lead</h2>
       <div class="apiary apiary-lead">[Loading…]</div>
-      <h2>Activities</h2>
-      <div class="apiary apiary-activities">[Loading…]</div>
+      <h2>Groups</h2>
+      <div class="apiary apiary-groups">[Loading…]</div>
     </div>
 
     <script src="//www.w3.org/scripts/jquery/2.1.4/jquery.min"></script>


### PR DESCRIPTION
*&ldquo;As the process 2015 will be released next week, we have removed activities and coordination groups.&rdquo;*
&mdash; [Denis](https://lists.w3.org/Archives/Team/w3t-sys/2015JulAug/0368.html)

The [domain page example](https://w3c.github.io/apiary/examples/domain.html) stopped working after this change.

This PR removes support for the field `activities`, and adds support for `groups` instead.