### PR TITLE
jQuery: use symlink 2.1 instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Refer to [the W3C API](https://github.com/w3c/w3c-api) and its documentation for
 
 Include [jQuery](http://jquery.com/) and [Apiary](apiary.js) in your page:  
 ```html
-<script src="//www.w3.org/scripts/jquery/2.1.4/jquery.min"></script>
+<script src="//www.w3.org/scripts/jquery/2.1/jquery.min"></script>
 <script src="//w3c.github.io/apiary/apiary.js"></script>
 ```
 

--- a/examples/domain.html
+++ b/examples/domain.html
@@ -22,7 +22,7 @@
       <div class="apiary apiary-groups">[Loading…]</div>
     </div>
 
-    <script src="//www.w3.org/scripts/jquery/2.1.4/jquery.min"></script>
+    <script src="//www.w3.org/scripts/jquery/2.1/jquery.min"></script>
     <script src="../apiary.js"></script>
   </body>
 

--- a/examples/group.html
+++ b/examples/group.html
@@ -22,7 +22,7 @@
       <div class="apiary apiary-chairs">[Loading…]</div>
     </div>
 
-    <script src="//www.w3.org/scripts/jquery/2.1.4/jquery.min"></script>
+    <script src="//www.w3.org/scripts/jquery/2.1/jquery.min"></script>
     <script src="../apiary.js"></script>
   </body>
 

--- a/examples/user.html
+++ b/examples/user.html
@@ -22,7 +22,7 @@
       <div class="apiary apiary-specifications">[Loading…]</div>   
     </div> 
 
-    <script src="//www.w3.org/scripts/jquery/2.1.4/jquery.min"></script>
+    <script src="//www.w3.org/scripts/jquery/2.1/jquery.min"></script>
     <script src="../apiary.js"></script>
   </body>
 


### PR DESCRIPTION
&hellip;to use the latest patch available.