### PR TITLE
Crawl the API à la HATEOAS

### DIFF
--- a/examples/domain.html
+++ b/examples/domain.html
@@ -18,7 +18,7 @@
     <div aria-live="polite">
       <h1 class="apiary apiary-name">[Loading…]</h1>
       <h2>Lead</h2>
-      <div class="apiary apiary-lead">[Loading…]</div>
+      <div class="apiary apiary-lead-title">[Loading…]</div>
       <h2>Groups</h2>
       <div class="apiary apiary-groups">[Loading…]</div>
     </div>

--- a/examples/group.html
+++ b/examples/group.html
@@ -20,6 +20,8 @@
       <p class="apiary apiary-description">[Loading…]</p>
       <h2>Chairs</h2>
       <div class="apiary apiary-chairs">[Loading…]</div>
+      <h2>Team contacts</h2>
+      <div class="apiary apiary-team_contacts">[Loading…]</div>
     </div>
 
     <script src="//www.w3.org/scripts/jquery/2.1/jquery.min"></script>

--- a/examples/user.html
+++ b/examples/user.html
@@ -17,7 +17,7 @@
 
     <div aria-live="polite">
       <h1><span class="apiary apiary-family">[Loading…]</span>, <span class="apiary apiary-given">[Loading…]</span></h1>
-      <div class="apiary apiary-photo">[Loading…]</div>
+      <div class="apiary apiary-photos">[Loading…]</div>
       <h2>Specs contributed to</h2>
       <div class="apiary apiary-specifications">[Loading…]</div>   
     </div> 


### PR DESCRIPTION
**Done:**
* Crawl the API in a [HATEOAS](https://en.wikipedia.org/wiki/HATEOAS) manner; ie discovering entities, properties and links dynamically instead of hard-coding them. **Fixes #15.**  
(This does *not* ensure that *all* data from the API is retrievable now; we still have to teach Apiary how to map certain patterns to HTML elements. Also, there are some inconsistencies in the API that have to be resolved for certain properties to work in Apiary&nbsp;&mdash;&nbsp;see &ldquo;to do&rdquo; below)
* Always invoke the API with `embed=true`, to save on HTTP requests sometimes. **Fixes #18.**
* Implement a very simple cache, that ensures no API URL will be called twice.

**To do:**
* Update README (will do in a separate PR).
* Update the documentation comments of a few functions that have changed here.
* [ ] w3c/w3c-api#28.
* [ ] w3c/w3c-api#29.
* [ ] w3c/w3c-api#30.