### PR TITLE
Fix bug using Object.keys() in IE9

### DIFF
--- a/apiary.js
+++ b/apiary.js
@@ -126,7 +126,7 @@
     for (key in keys) {
       i = keys[key];
       if (json.hasOwnProperty(i)) {
-        if (1 === Object.keys(json[i]).length && json[i].hasOwnProperty('href')) {
+        if ('object' === typeof json[i] && 1 === Object.keys(json[i]).length && json[i].hasOwnProperty('href')) {
           get(json[i].href, crawl);
         } else {
           injectValues(i, json[i]);


### PR DESCRIPTION
`Object.keys()` is supported in IE9, but its behaviour when it receives a `String` is different compared to Chrom* and FF:

**Chrom*, FF:**
```javascript
Object.keys('foo')
["0", "1", "2"]
```

**IE9**
```javascript
Object.keys('foo')
Error
```

This PR should fix the bug that Philipp Hoschka found in IE.