### PR TITLE
Now using the official URI for the W3C API

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ With Apiary, you can inject data that is retrieved using the W3C API, in a decla
 Examples are also provided.
 
 Refer to [the W3C API](https://github.com/w3c/w3c-api) and its documentation for details
-\[[overview](https://w3c.github.io/w3c-api/); [reference](https://api-test.w3.org/doc)\].
+\[[overview](https://w3c.github.io/w3c-api/); [reference](https://api.w3.org/doc)\].
 
 ## Live examples
 
@@ -55,7 +55,7 @@ The lead of this domain is: <span class="apiary-lead"></span>.
 The container element should have *one* of these *data-&#42;* attributes, and its value should be a valid ID:
 * `data-domain-id`
 * `data-group-id`
-* `data-user-id` (use [the **user hash**](https://api-test.w3.org/doc#get--users-%7Bhash%7D))
+* `data-user-id` (use [the **user hash**](https://api.w3.org/doc#get--users-%7Bhash%7D))
 
 A placeholder is any element with a class beginning with `apiary-`.
 Bear in mind that a new chunk of DOM will be inserted there; whatever that placeholder contains will be lost.
@@ -66,7 +66,7 @@ For example:
 ```
 
 For consistency (and to adhere to the [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)),
-the suffix part of these placeholders is equal to [the object keys returned by the API](https://api-test.w3.org/doc).
+the suffix part of these placeholders is equal to [the object keys returned by the API](https://api.w3.org/doc).
 
 The additional class `apiary` in the example files is ignored by Apiary itself but you may wish to include it anyway to all placeholders in your documents for easier CSS styling.
 

--- a/apiary.js
+++ b/apiary.js
@@ -5,7 +5,7 @@
 
   // Pseudo-constants:
   var VERSION            = '0.4.0';
-  var BASE_URL           = 'https://api-test.w3.org/';
+  var BASE_URL           = 'https://api.w3.org/';
   var USER_PROFILE_URL   = 'https://www.w3.org/users/';
   var APIARY_PLACEHOLDER = /[\^\ ]apiary-([^\ ]+)/g;
   var APIARY_SELECTOR    = '[class^="apiary"]';


### PR DESCRIPTION
Switching from https://api-test.w3.org/ to https://api.w3.org/