### PR TITLE
Fixes and improvements for production use

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,6 @@
-
 # The MIT License (MIT)
 
-Copyright © 2015 [World Wide Web Consortium](http://www.w3.org/)
+Copyright © 2015&ndash;2016 [World Wide Web Consortium](http://www.w3.org/)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the “software”), to deal in
 the software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
@@ -13,4 +12,3 @@ The above copyright notice and this permission notice shall be included in all c
 for a particular purpose and noninfringement.
 In no event shall the authors or copyright holders be liable for any claim, damages or other liability, whether in an action of contract, tort or otherwise,
 arising from, out of or in connection with the software or the use or other dealings in the software.**
-

--- a/README.md
+++ b/README.md
@@ -79,6 +79,6 @@ $ jsdoc ./apiary.js --destination ./doc/ --access all --encoding utf8 --verbose
 
 ## Credits
 
-Copyright © 2015 [World Wide Web Consortium](http://www.w3.org/)
+Copyright © 2015&ndash;2016 [World Wide Web Consortium](http://www.w3.org/)
 
 This project is licensed [under the terms of the MIT license](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -26,39 +26,39 @@ Include [Apiary](apiary.js) in your page:
 
 ### Add your API key
 
-Specify your W3C API key, adding a *data-api-key* attribute to the HTML element, eg:  
+Specify your W3C API key, adding a `data-apiary-key` attribute to the HTML element, eg:  
 ```html
-<html data-api-key="abc123def456">
+<html data-apiary-key="abc123def456">
 ```
 (You can get an API key very easily; refer to [the documentation](https://w3c.github.io/w3c-api/#apikeys).
 The examples provided here work with a public API key that is registered to test Apiary only; don't try to use it elsewhere.)
 
 ### Specify an entity ID
 
-Specify the ID of the *entity* you want, adding a *data-&#42;* attribute to a container element, eg:  
+Specify the ID of the *entity* you want, adding a `data-apiary-&#42;` attribute to a container element, eg:  
 ```html
-<main data-group-id="68239">
+<main data-apiary-group="68239">
 ```
 
 ### Add placeholders
 
 Finally, add *placeholders* wherever you want real data about that *entity*, eg:  
 ```html
-The chairs of this group are: <span class="apiary-chairs"></span>.
+The chairs of this group are: <span data-apiary="chairs"></span>.
 ```
 
 ## Reference
 
-The container element should have *one* of these *data-&#42;* attributes, and its value should be a valid ID:
-* `data-group-id`
-* `data-user-id` (use [the **user hash**](https://api.w3.org/doc#get--users-%7Bhash%7D))
+The container element should have *one* of these *data-apiary-&#42;* attributes, and its value should be a valid ID:
+* `data-apiary-group`
+* `data-apiary-user` (use [the **user hash**](https://api.w3.org/doc#get--users-%7Bhash%7D))
 
-A placeholder is any element with a class beginning with `apiary-`.
+A placeholder is any element with a `data-apiary` attribute.
 Bear in mind that a new chunk of DOM will be inserted there; whatever that placeholder contains will be lost.
 We recommend that you have something in there giving users a hint that data is being loaded dynamically.
 For example:
 ```html
-<div class="apiary-chairs">[Loading…]</div>
+<div data-apiary="chairs">[Loading…]</div>
 ```
 
 For consistency (and to adhere to the [POLA](https://en.wikipedia.org/wiki/Principle_of_least_astonishment)),

--- a/examples/group.html
+++ b/examples/group.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 
-<html lang="en-GB" data-api-key="f093zc7jyxskgscw0kkgk4w4go0w80k">
+<html lang="en-GB" data-apiary-key="f093zc7jyxskgscw0kkgk4w4go0w80k" data-apiary-mode="debug">
 
   <head>
     <meta charset="utf-8">
-    <title class="apiary apiary-name">[Loading…]</title>
+    <title data-apiary="name">[Loading…]</title>
     <meta name="description" content="A group page">
     <meta name="keywords"    content="w3c,w3,w3.org,group,page">
     <meta name="author"      content="W3C">
@@ -13,15 +13,22 @@
     <link rel="stylesheet" type="text/css" href="highlight.css">
   </head>
 
-  <body data-group-id="68239">
+  <body data-apiary-group="68239">
 
     <div aria-live="polite">
-      <h1><span class="apiary apiary-name">[Loading…]</span> <em class="apiary apiary-type">[Loading…]</em></h1>
-      <p class="apiary apiary-description">[Loading…]</p>
+      <h1>
+        <span data-apiary="name">[Loading…]</span>
+        <br />
+        <em data-apiary="type">[Loading…]</em>
+      </h1>
+      <p>
+        Chartered <span data-apiary="start-date"></span>&ndash;<span data-apiary="end-date"></span>
+      </p>
+      <p data-apiary="description">[Loading…]</p>
       <h2>Chairs</h2>
-      <div class="apiary apiary-chairs">[Loading…]</div>
+      <div data-apiary="chairs">[Loading…]</div>
       <h2>Team contacts</h2>
-      <div class="apiary apiary-team-contacts">[Loading…]</div>
+      <div data-apiary="team-contacts">[Loading…]</div>
     </div>
 
     <script src="../apiary.js"></script>

--- a/examples/highlight.css
+++ b/examples/highlight.css
@@ -13,11 +13,14 @@ body > div > * {
   padding:          0.25em 8rem;
 }
 
-.apiary {
+code {
+  font-family: monospace;
+}
+
+[data-apiary] {
   background-color: #ffe0e0;
 }
 
 .apiary-done {
   background-color: #e0ffe0;
 }
-

--- a/examples/user.html
+++ b/examples/user.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 
-<html lang="en-GB" data-api-key="f093zc7jyxskgscw0kkgk4w4go0w80k">
+<html lang="en-GB" data-apiary-key="f093zc7jyxskgscw0kkgk4w4go0w80k" data-apiary-mode="debug">
 
   <head>
     <meta charset="utf-8">
-    <title class="apiary apiary-name">[Loading…]</title>
+    <title data-apiary="name">[Loading…]</title>
     <meta name="description" content="A user page">
     <meta name="keywords"    content="w3c,w3,w3.org,user,page">
     <meta name="author"      content="W3C">
@@ -13,13 +13,20 @@
     <link rel="stylesheet" type="text/css" href="highlight.css">
   </head>
 
-  <body data-user-id="ggdj8tciu9kwwc4o4ww888ggkwok0c8">
+  <body data-apiary-user="ggdj8tciu9kwwc4o4ww888ggkwok0c8">
 
     <div aria-live="polite">
-      <h1><span class="apiary apiary-family">[Loading…]</span>, <span class="apiary apiary-given">[Loading…]</span></h1>
-      <div class="apiary apiary-photos">[Loading…]</div>
+      <h1>
+        <span data-apiary="family">[Loading…]</span>,
+        <span data-apiary="given">[Loading…]</span>
+        <span data-apiary="work-title (${work-title})">[Loading…]</span>
+      </h1>
+      <div data-apiary="photos">[Loading…]</div>
       <h2>Specs contributed to</h2>
-      <div class="apiary apiary-specifications">[Loading…]</div>
+      <p>Hover over specs to view descriptions.</p>
+      <div data-apiary="specifications">[Loading…]</div>
+      <h2>Member of groups</h2>
+      <div data-apiary="groups ${name}">[Loading…]</div>
     </div>
 
     <script src="../apiary.js"></script>


### PR DESCRIPTION
Apiary `2.0.0`, ready to be used in W3C WG pages:

* Use `data-*` attributes instead of classes
* Add `debug` mode
* Fix traversal of nested objects and properties in the API
* Allow custom expressions (more flexible presentation)
* Improve default presentation of common types of objects (users, specs, etc)
* Update documentation accordingly
* Bump version
* Update year in copyright notices